### PR TITLE
Update access to TM AI-assisted mapping tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Microsoft has a continued interest in supporting a thriving OpenStreetMap ecosys
 Maybe. Never overwrite the hard work of other contributors or blindly import data into OSM without first checking the local quality. While our metrics show that this data meets or exceeds the quality of hand-drawn building footprints, the data does vary in quality from place to place, between rural and urban, mountains and plains, and so on. Inspect quality locally and discuss an import plan with the community. Always follow the [OSM import community guidelines](https://wiki.openstreetmap.org/wiki/Import/Guidelines).
 
 ### Will the data be used or made available in the larger OpenStreetMap ecosystem?
-Yes. Currently Microsoft Open Buildings dataset is used in ml-enabler for task creation. You can try it out at [AI assisted Tasking Manager](https://tasks-assisted.hotosm.org/). The data will also be made available in Facebook [RapiD](https://mapwith.ai/rapid#background=Bing&disable_features=boundaries&map=2.00/0.0/0.0).
+Yes. The [HOT Tasking Manager](https://tasks.hotosm.org) has integrated Facebook [RapiD](https://mapwith.ai/rapid#background=Bing&disable_features=boundaries&map=2.00/0.0/0.0) where the data has been made available. 
 
 ### How did we create the data?
 The building extraction is done in two stages:


### PR DESCRIPTION
The tasks-assisted app was phased out after we integrated RapiD into tasks.hotosm.org directly. Since [there were questions](https://help.openstreetmap.org/questions/84532/is-hot-ai-assisted-editor-still-exists?page=1&focusedAnswerId=84537#84537) stemming from this page, I propose some text changes to clear that up.