### PR TITLE
Update RapiD link to v2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Microsoft has a continued interest in supporting a thriving OpenStreetMap ecosys
 Maybe. Never overwrite the hard work of other contributors or blindly import data into OSM without first checking the local quality. While our metrics show that this data meets or exceeds the quality of hand-drawn building footprints, the data does vary in quality from place to place, between rural and urban, mountains and plains, and so on. Inspect quality locally and discuss an import plan with the community. Always follow the [OSM import community guidelines](https://wiki.openstreetmap.org/wiki/Import/Guidelines).
 
 ### Will the data be used or made available in the larger OpenStreetMap ecosystem?
-Yes. The [HOT Tasking Manager](https://tasks.hotosm.org) has integrated Facebook [RapiD](https://mapwith.ai/rapid#background=Bing&disable_features=boundaries&map=2.00/0.0/0.0) where the data has been made available. 
+Yes. The [HOT Tasking Manager](https://tasks.hotosm.org) has integrated Facebook [RapiD](https://rapideditor.org/edit) where the data has been made available. 
 
 ### How did we create the data?
 The building extraction is done in two stages:


### PR DESCRIPTION
Rapid is now using https://rapideditor.org/edit as RapiD v2.2 link rather than https://mapwith.ai/