### PR TITLE
Preserve 'height' Attribute in Output GeoJSON

### DIFF
--- a/examples/example_building_footprints.ipynb
+++ b/examples/example_building_footprints.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,17 +62,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The input area spans 1 tiles: [21230030]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "quad_keys = set()\n",
     "for tile in list(mercantile.tiles(minx, miny, maxx, maxy, zooms=9)):\n",
@@ -95,17 +87,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 1/1 [01:21<00:00, 81.05s/it]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = pd.read_csv(\n",
     "    \"https://minedbuildings.blob.core.windows.net/global-buildings/dataset-links.csv\"\n",
@@ -153,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/example_building_footprints.ipynb
+++ b/examples/example_building_footprints.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
     "from tqdm import tqdm\n",
     "import os\n",
     "import tempfile\n",
-    "import fiona"
+    "#remove fiona"
    ]
   },
   {
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,9 +62,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The input area spans 1 tiles: [21230030]\n"
+     ]
+    }
+   ],
    "source": [
     "quad_keys = set()\n",
     "for tile in list(mercantile.tiles(minx, miny, maxx, maxy, zooms=9)):\n",
@@ -87,17 +95,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1/1 [01:21<00:00, 81.05s/it]\n"
+     ]
+    }
+   ],
    "source": [
     "df = pd.read_csv(\n",
     "    \"https://minedbuildings.blob.core.windows.net/global-buildings/dataset-links.csv\"\n",
     ")\n",
     "\n",
     "idx = 0\n",
-    "combined_rows = []\n",
-    "\n",
+    "combined_gdf = gpd.GeoDataFrame()\n",
     "with tempfile.TemporaryDirectory() as tmpdir:\n",
     "    # Download the GeoJSON files for each tile that intersects the input geometry\n",
     "    tmp_fns = []\n",
@@ -121,17 +136,11 @@
     "\n",
     "    # Merge the GeoJSON files into a single file\n",
     "    for fn in tmp_fns:\n",
-    "        with fiona.open(fn, \"r\") as f:\n",
-    "            for row in tqdm(f):\n",
-    "                row = dict(row)\n",
-    "                shape = shapely.geometry.shape(row[\"geometry\"])\n",
-    "\n",
-    "                if aoi_shape.contains(shape):\n",
-    "                    if \"id\" in row:\n",
-    "                        del row[\"id\"]\n",
-    "                    row[\"properties\"] = {\"id\": idx}\n",
-    "                    idx += 1\n",
-    "                    combined_rows.append(row)"
+    "        gdf = gpd.read_file(fn)  # Read each file into a GeoDataFrame\n",
+    "        gdf = gdf[gdf.geometry.within(aoi_shape)]  # Filter geometries within the AOI\n",
+    "        gdf['id'] = range(idx, idx + len(gdf))  # Update 'id' based on idx\n",
+    "        idx += len(gdf)\n",
+    "        combined_gdf = pd.concat([combined_gdf,gdf],ignore_index=True)"
    ]
   },
   {
@@ -144,20 +153,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "schema = {\"geometry\": \"Polygon\", \"properties\": {\"id\": \"int\"}}\n",
-    "\n",
-    "with fiona.open(output_fn, \"w\", driver=\"GeoJSON\", crs=\"EPSG:4326\", schema=schema) as f:\n",
-    "    f.writerecords(combined_rows)"
+    "combined_gdf = combined_gdf.to_crs('EPSG:4326')\n",
+    "combined_gdf.to_file(output_fn, driver='GeoJSON')"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "BPS",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request addresses an issue where the original 'properties' values were being overwritten by a new 'id' value, resulting in the omission of 'height' and 'confidence' information when downloading data using the example notebook script. To resolve this, I have implemented an alternative approach utilizing a GeoDataFrame. This modification ensures that the 'height' attribute is preserved and included in the output GeoJSON file, enhancing the data's completeness and utility. This change is crucial for users who rely on the 'height' attribute for their analyses or applications.